### PR TITLE
Update spelling license -> licence

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ for the design of the service.
 
 Understanding the people who use a service and what they want is
 critical to building a service that works for them. For example, users
-of a driver's license renewal service include any Ontarian with a
-driver’s license.
+of a driver's licence renewal service include any Ontarian with a
+driver’s licence.
 
 It’s easy to make assumptions about users or be influenced by personal
 experiences. When thinking about users, it’s important to find people


### PR DESCRIPTION
Suggested edit to match style guide practice of using licence (noun), license (verb).